### PR TITLE
Add JSON test data for Actor Service's bulk get groups

### DIFF
--- a/jira/cloud/test/actor_service_bulk_get_groups.json
+++ b/jira/cloud/test/actor_service_bulk_get_groups.json
@@ -1,0 +1,16 @@
+{
+  "maxResults": 50,
+  "startAt": 0,
+  "total": 1,
+  "isLast": true,
+  "values": [
+    {
+      "name": "site-admins",
+      "groupId": "94af0e5e-018a-422d-bffa-e41fc5b71d29"
+    },
+    {
+      "name": "jira-admins-mobilesolutionworks",
+      "groupId": "2eeab65d-ab39-4eee-965b-fd2a8bed9d12"
+    }
+  ]
+}

--- a/jira/cloud/test/actor_service_bulk_get_groups2.json
+++ b/jira/cloud/test/actor_service_bulk_get_groups2.json
@@ -1,0 +1,12 @@
+{
+  "maxResults": 50,
+  "startAt": 0,
+  "total": 1,
+  "isLast": true,
+  "values": [
+    {
+      "name": "site-admins",
+      "groupId": "94af0e5e-018a-422d-bffa-e41fc5b71d29"
+    }
+  ]
+}


### PR DESCRIPTION
Two new JSON test data files are added for the Actor Service's bulk get groups functionality. These files, ‘actor_service_bulk_get_groups.json’ and ‘actor_service_bulk_get_groups2.json’, simulate different responses, which can be used for effective unit testing. This will ensure that our code handles all possible responses correctly.