### PR TITLE
Refactor permission addition function in Bamboo helpers

### DIFF
--- a/bamboo/bamboo_permissions_helpers.go
+++ b/bamboo/bamboo_permissions_helpers.go
@@ -124,9 +124,10 @@ func updateItemPermission[K any](
 	// If the item is found, calculate the permissions to add and remove.
 	if item != nil {
 		adding, removing := item.DeltaPermissions(newPermissions)
-		// Add new permissions if there are any to add.
+		// Add new permissions if there are any to add. We are not adding delta to ensure
+		// all missing permissions are restored.
 		if len(adding) > 0 {
-			err = addPermissions(itemId, key, adding)
+			err = addPermissions(itemId, key, newPermissions)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The code modification in the Bamboo permissions helper aims to address an issue in the permissions addition function. The adjusted code ensures that all missing permissions are restored by not just adding the delta but all new permissions. This way, we can provide a fuller and more precise permission administration experience in Bamboo.