### PR TITLE
Disable large file storage in Bamboo

### DIFF
--- a/bamboo/bamboo_repository_service.go
+++ b/bamboo/bamboo_repository_service.go
@@ -44,7 +44,7 @@ rootEntity: !!com.atlassian.bamboo.specs.model.repository.bitbucket.server.Bitbu
     id: %s
     name: %s
   sshCloneUrl: %s
-  useLfs: true
+  useLfs: false
 specModelVersion: 9.3.0
 `,
 				create.Name,


### PR DESCRIPTION
The line 'useLfs' in the bamboo_repository_service.go file has been adjusted from true to false. This modification disables the use of Large File Storage (LFS) in Bamboo.