### PR TITLE
Implement branch restriction methods for Bitbucket

### DIFF
--- a/bitbucket/bitbucket_branch_restrictions.go
+++ b/bitbucket/bitbucket_branch_restrictions.go
@@ -1,0 +1,34 @@
+package bitbucket
+
+type BranchRestrictionMatcherType struct {
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+type BranchRestrictionMatcher struct {
+	Id        string                       `json:"id,omitempty"`
+	DisplayId string                       `json:"displayId,omitempty"`
+	Type      BranchRestrictionMatcherType `json:"type,omitempty"`
+}
+
+type BranchRestrictionScope struct {
+	Type       string `json:"type,omitempty"`
+	ResourceId int    `json:"resourceId,omitempty"`
+}
+
+type BranchRestriction struct {
+	Id      int                      `json:"id,omitempty"`
+	Matcher BranchRestrictionMatcher `json:"matcher,omitempty"`
+	Scope   BranchRestrictionScope   `json:"scope,omitempty"`
+	Type    string                   `json:"type,omitempty"`
+	Users   []string                 `json:"users,omitempty"`
+	Groups  []string                 `json:"groups,omitempty"`
+}
+
+type BranchRestrictionReply struct {
+	Id      int64                    `json:"id,omitempty"`
+	Matcher BranchRestrictionMatcher `json:"matcher,omitempty"`
+	Scope   BranchRestrictionScope   `json:"scope,omitempty"`
+	Type    string                   `json:"type,omitempty"`
+	Users   []User                   `json:"users,omitempty"`
+	Groups  []string                 `json:"groups,omitempty"`
+}

--- a/bitbucket/bitbucket_project_service_ext_branch_restrictions.go
+++ b/bitbucket/bitbucket_project_service_ext_branch_restrictions.go
@@ -1,0 +1,63 @@
+package bitbucket
+
+import (
+	"fmt"
+	"github.com/yunarta/terraform-api-transport/transport"
+	"net/http"
+)
+
+func (service *ProjectService) CreateBranchRestrictions(project string, restriction []BranchRestriction) ([]BranchRestrictionReply, error) {
+	// Sending a POST request to create a project
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPost,
+		Url:    fmt.Sprintf("/rest/branch-permissions/latest/projects/%s/restrictions", project),
+		Payload: &XBulkJsonPayload{
+			Payload: restriction,
+		},
+	}, 200)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var response []BranchRestrictionReply
+
+	// Parsing the response
+	err = reply.Object(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *ProjectService) ReadBranchRestriction(project string, restrictionId int64) (*BranchRestrictionReply, error) {
+	// Sending a POST request to create a project
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodGet,
+		Url:    fmt.Sprintf("/rest/branch-permissions/latest/projects/%s/restrictions/%d", project, restrictionId),
+	}, 200)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var response = &BranchRestrictionReply{}
+
+	// Parsing the response
+	err = reply.Object(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *ProjectService) DeleteBranchRestriction(project string, restrictionId int64) error {
+	// Sending a POST request to create a project
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodDelete,
+		Url:    fmt.Sprintf("/rest/branch-permissions/latest/projects/%s/restrictions/%d", project, restrictionId),
+	}, 204)
+	return err
+}

--- a/bitbucket/bitbucket_repository_service_ext_branch_restrictions.go
+++ b/bitbucket/bitbucket_repository_service_ext_branch_restrictions.go
@@ -1,0 +1,63 @@
+package bitbucket
+
+import (
+	"fmt"
+	"github.com/yunarta/terraform-api-transport/transport"
+	"net/http"
+)
+
+func (service *RepositoryService) CreateBranchRestrictions(project, repo string, restriction []BranchRestriction) ([]BranchRestrictionReply, error) {
+	// Sending a POST request to create a project
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPost,
+		Url:    fmt.Sprintf("/rest/branch-permissions/latest/projects/%s/repos/%s/restrictions", project, repo),
+		Payload: &XBulkJsonPayload{
+			Payload: restriction,
+		},
+	}, 200)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var response []BranchRestrictionReply
+
+	// Parsing the response
+	err = reply.Object(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *RepositoryService) ReadBranchRestriction(project, repo string, restrictionId int64) (*BranchRestrictionReply, error) {
+	// Sending a POST request to create a project
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodGet,
+		Url:    fmt.Sprintf("/rest/branch-permissions/latest/projects/%s/repos/%s/restrictions/%d", project, repo, restrictionId),
+	}, 200)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var response = &BranchRestrictionReply{}
+
+	// Parsing the response
+	err = reply.Object(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *RepositoryService) DeleteBranchRestriction(project, repo string, restrictionId int64) error {
+	// Sending a POST request to create a project
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodDelete,
+		Url:    fmt.Sprintf("/rest/branch-permissions/latest/projects/%s/repos/%s/restrictions/%d", project, repo, restrictionId),
+	}, 204)
+	return err
+}

--- a/bitbucket/misc_payload.go
+++ b/bitbucket/misc_payload.go
@@ -1,0 +1,42 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"github.com/yunarta/terraform-api-transport/transport"
+)
+
+// XBulkJsonPayload struct represents a payload with YAML data.
+// It is intended to be used with API requests or responses where the data content is in YAML format.
+type XBulkJsonPayload struct {
+	Payload any
+}
+
+// ContentMust returns the payload data as a byte slice.
+// This method is a 'must' version, meaning it assumes the operation will always succeed and does not return an error.
+func (m *XBulkJsonPayload) ContentMust() []byte {
+	content, _ := m.Content()
+	return content
+}
+
+// Accept returns the MIME type that this payload expects to receive.
+// Here, it is set to 'application/json', indicating that the payload expects to receive JSON-formatted data.
+func (m *XBulkJsonPayload) Accept() string {
+	return "application/json"
+}
+
+// ContentType returns the MIME type of the content this payload contains.
+// In this case, it returns 'application/x-yaml', indicating the content type is YAML.
+func (m *XBulkJsonPayload) ContentType() string {
+	return "application/vnd.atl.bitbucket.bulk+json"
+}
+
+// Content returns the payload data as a byte slice and an error.
+// In this implementation, it simply converts the YAML string to a byte slice and returns no error.
+func (m *XBulkJsonPayload) Content() ([]byte, error) {
+	payload, err := json.Marshal(m.Payload)
+	return payload, err
+}
+
+// This line ensures that XBulkJsonPayload implements the PayloadData interface from the transport package.
+// It's a compile-time assertion that validates interface compliance.
+var _ transport.PayloadData = &XBulkJsonPayload{}


### PR DESCRIPTION
Added Create, Read and Delete functions for branch restrictions in both Repository and Project Service in Bitbucket. Also introduced XBulkJsonPayload struct to handle payload transfer within these functions. Created respective structs for handling branch restriction data. This allows for better management and application of branch restrictions in Bitbucket repositories and projects.