### PR TITLE
Add support for Bitbucket merge checks

### DIFF
--- a/bitbucket/bitbucket_merge_checks.go
+++ b/bitbucket/bitbucket_merge_checks.go
@@ -1,0 +1,19 @@
+package bitbucket
+
+type MergeCheckDetail struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+type MergeCheck struct {
+	Details    MergeCheckDetail `json:"details"`
+	Enabled    bool             `json:"enabled"`
+	Configured bool             `json:"configured"`
+}
+
+type MergeChecksReply struct {
+	Values []MergeCheck `json:"values"`
+}
+
+type MergeCheckSetting struct {
+	RequiredCount string `json:"requiredCount"`
+}

--- a/bitbucket/bitbucket_project_service_ext_merge_checks.go
+++ b/bitbucket/bitbucket_project_service_ext_merge_checks.go
@@ -1,0 +1,77 @@
+package bitbucket
+
+import (
+	"fmt"
+	"github.com/yunarta/terraform-api-transport/transport"
+	"net/http"
+	"strconv"
+)
+
+func (service *ProjectService) EnableMergeCheck(project, check string) error {
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPut,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/settings/hooks/%s/enabled?enrich=true", project, check),
+	}, 200)
+	return err
+}
+
+func (service *ProjectService) DisableMergeCheck(project, check string) error {
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodDelete,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/settings/hooks/%s/enabled?enrich=true", project, check),
+	}, 200)
+	return err
+}
+
+func (service *ProjectService) ConfigureMergeCheck(project, check string, value int) error {
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPut,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/settings/hooks/%s/enabled?enrich=true", project, check),
+		Payload: &transport.JsonPayloadData{
+			Payload: map[string]string{
+				"requiredCount": strconv.Itoa(value),
+			},
+		},
+	}, 200)
+	return err
+}
+
+func (service *ProjectService) GetMergeChecks(project string) ([]MergeCheck, error) {
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodGet,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/settings/hooks", project),
+	}, 200)
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MergeChecksReply{}
+	// Parsing the response
+	err = reply.Object(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Values, nil
+}
+
+func (service *ProjectService) GetMergeCheckSetting(project, check string) (*MergeCheckSetting, error) {
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodGet,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/settings/hooks/%s/settings", project, check),
+	}, 200)
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MergeCheckSetting{}
+	// Parsing the response
+	err = reply.Object(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/bitbucket/bitbucket_repository_service_ext_merge_checks.go
+++ b/bitbucket/bitbucket_repository_service_ext_merge_checks.go
@@ -1,0 +1,77 @@
+package bitbucket
+
+import (
+	"fmt"
+	"github.com/yunarta/terraform-api-transport/transport"
+	"net/http"
+	"strconv"
+)
+
+func (service *RepositoryService) EnableMergeCheck(project, repo, check string) error {
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPut,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/settings/hooks/%s/enabled?enrich=true", project, repo, check),
+	}, 200)
+	return err
+}
+
+func (service *RepositoryService) DisableMergeCheck(project, repo, check string) error {
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodDelete,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/settings/hooks/%s/enabled?enrich=true", project, repo, check),
+	}, 200)
+	return err
+}
+
+func (service *RepositoryService) ConfigureMergeCheck(project, repo, check string, value int) error {
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPut,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/settings/hooks/%s/enabled?enrich=true", project, repo, check),
+		Payload: &transport.JsonPayloadData{
+			Payload: map[string]string{
+				"requiredCount": strconv.Itoa(value),
+			},
+		},
+	}, 200)
+	return err
+}
+
+func (service *RepositoryService) GetMergeChecks(project, repo string) ([]MergeCheck, error) {
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodGet,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/settings/hooks", project, repo),
+	}, 200)
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MergeChecksReply{}
+	// Parsing the response
+	err = reply.Object(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Values, nil
+}
+
+func (service *RepositoryService) GetMergeCheckSetting(project, check string) (*MergeCheckSetting, error) {
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodGet,
+		Url:    fmt.Sprintf("/rest/api/latest/projects/%s/settings/hooks/%s/settings", project, check),
+	}, 200)
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MergeCheckSetting{}
+	// Parsing the response
+	err = reply.Object(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}


### PR DESCRIPTION
Implemented merge checks functionality within the Bitbucket package. Introduced new structs for merge check details and settings, and added methods to enable, disable, and configure merge checks in both RepositoryService and ProjectService. This provides more granular control over merge rules in Bitbucket repositories and projects.