### PR TITLE
Add ScanCI function to RepositoryService in Bamboo

### DIFF
--- a/bamboo/bamboo_repository_service.go
+++ b/bamboo/bamboo_repository_service.go
@@ -232,6 +232,15 @@ func (service *RepositoryService) EnableCI(repositoryId int, enableCi bool) erro
 	return err
 }
 
+func (service *RepositoryService) ScanCI(repositoryId int) error {
+	// Send a PUT request to update the repository's CI settings.
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPost,
+		Url:    fmt.Sprintf("/rest/api/latest/repository/%d/scanNow", repositoryId),
+	}, 204)
+	return err
+}
+
 func (service *RepositoryService) Update(repositoryId int, request CreateRepository) error {
 	// Send a PUT request to update the repository's CI settings.
 	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{


### PR DESCRIPTION
The code diff is primarily related to the addition of a new function, ScanCI, in the bamboo_repository_service go file. This function sends a POST request to trigger a CI scan for a specific repository in Bamboo, which enhances functionality of the Repository Service by providing a more hands-on control over the continuous integration process.