### PR TITLE
Add read operation to AgentAssignmentService in Bamboo API

### DIFF
--- a/bamboo/bamboo_agent_assignment.go
+++ b/bamboo/bamboo_agent_assignment.go
@@ -1,8 +1,20 @@
 package bamboo
 
-type AgentAssignment struct {
+type AgentQuery struct {
+	ExecutorType string `json:"executorType"`
+	ExecutorId   int64  `json:"executorId"`
+}
+
+type AgentAssignmentRequest struct {
 	ExecutorType   string `json:"executorType"`
 	ExecutorId     int64  `json:"executorId"`
 	EntityId       int64  `json:"entityId"`
 	AssignmentType string `json:"assignmentType"`
+}
+
+type AgentAssignment struct {
+	ExecutorType   string `json:"executorType"`
+	ExecutorId     int64  `json:"executorId"`
+	ExecutableId   int64  `json:"executableId"`
+	ExecutableType string `json:"executableType"`
 }

--- a/bamboo/bamboo_agent_assignment_service.go
+++ b/bamboo/bamboo_agent_assignment_service.go
@@ -11,7 +11,26 @@ type AgentAssignmentService struct {
 	transport transport.PayloadTransport
 }
 
-func (service *AgentAssignmentService) Create(request AgentAssignment) error {
+func (service *AgentAssignmentService) Read(request AgentQuery) (*[]AgentAssignment, error) {
+	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPost,
+		Url: fmt.Sprintf("/rest/api/latest/agent/assignment?executorType=%s&executorId=%d",
+			request.ExecutorType,
+			request.ExecutorId,
+		),
+		// Check for any errors. If there's an error, it's returned immediately.
+	}, 200)
+
+	deployment := make([]AgentAssignment, 0)
+	err = reply.Object(&deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deployment, nil
+}
+
+func (service *AgentAssignmentService) Create(request AgentAssignmentRequest) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodPost,
 		Url: fmt.Sprintf("/rest/api/latest/agent/assignment?executorType=%s&executorId=%d&entityId=%d&assignmentType=%s",
@@ -25,7 +44,7 @@ func (service *AgentAssignmentService) Create(request AgentAssignment) error {
 	return err
 }
 
-func (service *AgentAssignmentService) Delete(request AgentAssignment) error {
+func (service *AgentAssignmentService) Delete(request AgentAssignmentRequest) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodDelete,
 		Url: fmt.Sprintf("/rest/api/latest/agent/assignment?executorType=%s&executorId=%d&entityId=%d&assignmentType=%s",


### PR DESCRIPTION
Implemented a 'read' function in the AgentAssignmentService of the Bamboo API. This function sends a POST request to retrieve agent assignments based on provided query parameters. Also, there has been a refactor of the request & assignment struct, introducing an AgentQuery and AgentAssignmentRequest, enhancing encapsulation and code clarity.