### PR TITLE
Add new payload type and repository delete methods

### DIFF
--- a/bamboo/bamboo_repository_service.go
+++ b/bamboo/bamboo_repository_service.go
@@ -18,23 +18,25 @@ type RepositoryService struct {
 
 // CreateRepository holds the data necessary to create a new repository.
 type CreateRepository struct {
-	Name           string
-	ProjectKey     string
-	RepositorySlug string
-	ServerId       string
-	ServerName     string
-	CloneUrl       string
+	Name             string
+	ProjectKey       string
+	RepositorySlug   string
+	RepositoryBranch string
+	ServerId         string
+	ServerName       string
+	CloneUrl         string
 }
 
 // CreateProjectRepository holds the data necessary to create a new repository.
 type CreateProjectRepository struct {
-	Project        string
-	Name           string
-	ProjectKey     string
-	RepositorySlug string
-	ServerId       string
-	ServerName     string
-	CloneUrl       string
+	Project          string
+	Name             string
+	ProjectKey       string
+	RepositorySlug   string
+	RepositoryBranch string
+	ServerId         string
+	ServerName       string
+	CloneUrl         string
 }
 
 // Create initializes a new repository with the specified parameters.
@@ -112,7 +114,7 @@ rootEntity: !!com.atlassian.bamboo.specs.model.repository.bitbucket.server.Bitbu
   name: %s
   projectKey: %s
   repositorySlug: %s
-  branch: master
+  branch: %s
   server:
     id: %s
     name: %s
@@ -124,6 +126,7 @@ specModelVersion: 9.3.0
 				create.Name,
 				create.ProjectKey,
 				create.RepositorySlug,
+				create.RepositoryBranch,
 				create.ServerId,
 				create.ServerName,
 				create.CloneUrl,
@@ -276,7 +279,7 @@ rootEntity: !!com.atlassian.bamboo.specs.model.repository.bitbucket.server.Bitbu
   name: %s
   projectKey: %s
   repositorySlug: %s
-  branch: master
+  branch: %s
   server:
     id: %s
     name: %s
@@ -288,6 +291,7 @@ specModelVersion: 9.3.0
 				request.Name,
 				request.ProjectKey,
 				request.RepositorySlug,
+				request.RepositoryBranch,
 				request.ServerId,
 				request.ServerName,
 				request.CloneUrl,
@@ -338,7 +342,7 @@ rootEntity: !!com.atlassian.bamboo.specs.model.repository.bitbucket.server.Bitbu
   name: %s
   projectKey: %s
   repositorySlug: %s
-  branch: master
+  branch: %s
   server:
     id: %s
     name: %s
@@ -351,6 +355,7 @@ specModelVersion: 9.3.0
 				request.Name,
 				request.ProjectKey,
 				request.RepositorySlug,
+				request.RepositoryBranch,
 				request.ServerId,
 				request.ServerName,
 				request.CloneUrl,
@@ -362,6 +367,38 @@ specModelVersion: 9.3.0
 	}
 
 	return nil
+}
+
+func (service *RepositoryService) Delete(repositoryId int) error {
+	// Send a DELETE request to remove an accessor from the repository.
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPost,
+		Url:    "/admin/deleteLinkedRepository.action",
+		Payload: &XFormPayload{
+			Data: fmt.Sprintf("repositoryId=%d", repositoryId),
+		},
+		Headers: map[string]string{
+			"X-Atlassian-Token": "no-check",
+		},
+	}, 200, 302)
+
+	return err
+}
+
+func (service *RepositoryService) DeleteProject(project string, repositoryId int) error {
+	// Send a DELETE request to remove an accessor from the repository.
+	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
+		Method: http.MethodPost,
+		Url:    "/project/deleteProjectRepository.action",
+		Payload: &XFormPayload{
+			Data: fmt.Sprintf("repositoryId=%d&projectKey=%s", repositoryId, project),
+		},
+		Headers: map[string]string{
+			"X-Atlassian-Token": "no-check",
+		},
+	}, 200, 302)
+
+	return err
 }
 
 // ReadAccessor retrieves a list of repositories that a specific repository has access to.

--- a/bamboo/misc_payload.go
+++ b/bamboo/misc_payload.go
@@ -35,3 +35,37 @@ func (m *XYamlPayload) Content() ([]byte, error) {
 // This line ensures that XYamlPayload implements the PayloadData interface from the transport package.
 // It's a compile-time assertion that validates interface compliance.
 var _ transport.PayloadData = &XYamlPayload{}
+
+// XYamlPayload struct represents a payload with YAML data.
+// It is intended to be used with API requests or responses where the data content is in YAML format.
+type XFormPayload struct {
+	Data string
+}
+
+// ContentMust returns the payload data as a byte slice.
+// This method is a 'must' version, meaning it assumes the operation will always succeed and does not return an error.
+func (m *XFormPayload) ContentMust() []byte {
+	return []byte(m.Data)
+}
+
+// Accept returns the MIME type that this payload expects to receive.
+// Here, it is set to 'application/json', indicating that the payload expects to receive JSON-formatted data.
+func (m *XFormPayload) Accept() string {
+	return "text/html"
+}
+
+// ContentType returns the MIME type of the content this payload contains.
+// In this case, it returns 'application/x-yaml', indicating the content type is YAML.
+func (m *XFormPayload) ContentType() string {
+	return "application/x-www-form-urlencoded"
+}
+
+// Content returns the payload data as a byte slice and an error.
+// In this implementation, it simply converts the YAML string to a byte slice and returns no error.
+func (m *XFormPayload) Content() ([]byte, error) {
+	return []byte(m.Data), nil
+}
+
+// This line ensures that XYamlPayload implements the PayloadData interface from the transport package.
+// It's a compile-time assertion that validates interface compliance.
+var _ transport.PayloadData = &XFormPayload{}


### PR DESCRIPTION
Introduce `XFormPayload` for handling form-encoded data and enhance repository management. Added `Delete` and `DeleteProject` methods to `RepositoryService` for handling repository deletion with improved payload support. Updated `CreateRepository` and `CreateProjectRepository` to include branch handling.