### PR TITLE
Escape query parameters in API requests.

### DIFF
--- a/bitbucket/bitbucket_project_permission_service.go
+++ b/bitbucket/bitbucket_project_permission_service.go
@@ -5,6 +5,7 @@ import (
 	"github.com/yunarta/terraform-api-transport/transport"
 	"github.com/yunarta/terraform-atlassian-api-client/util"
 	"net/http"
+	"net/url"
 )
 
 const (
@@ -56,7 +57,7 @@ func (service *ProjectService) readGroupsPermission(projectKey string, groupName
 func (service *ProjectService) addGroupPermission(projectKey string, username string, permission string) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodPut,
-		Url:    fmt.Sprintf(addGroupProjectPermissionEndPoint, projectKey, username, permission),
+		Url:    fmt.Sprintf(addGroupProjectPermissionEndPoint, projectKey, url.QueryEscape(username), url.QueryEscape(permission)),
 	}, 204)
 	return err
 }
@@ -64,7 +65,7 @@ func (service *ProjectService) addGroupPermission(projectKey string, username st
 func (service *ProjectService) removeGroupPermission(projectKey string, username string) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodDelete,
-		Url:    fmt.Sprintf(groupProjectPermissionEndPoint, projectKey, username),
+		Url:    fmt.Sprintf(groupProjectPermissionEndPoint, projectKey, url.QueryEscape(username)),
 	}, 204)
 	return err
 }
@@ -90,7 +91,7 @@ func (service *ProjectService) readUsersPermission(projectKey string, user strin
 func (service *ProjectService) addUserPermission(projectKey string, username string, permission string) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodPut,
-		Url:    fmt.Sprintf(addUserProjectPermissionEndPoint, projectKey, username, permission),
+		Url:    fmt.Sprintf(addUserProjectPermissionEndPoint, projectKey, url.QueryEscape(username), url.QueryEscape(permission)),
 	}, 204)
 	return err
 }
@@ -98,7 +99,7 @@ func (service *ProjectService) addUserPermission(projectKey string, username str
 func (service *ProjectService) removeUserPermission(projectKey string, username string) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodDelete,
-		Url:    fmt.Sprintf(userProjectPermissionEndPoint, projectKey, username),
+		Url:    fmt.Sprintf(userProjectPermissionEndPoint, projectKey, url.QueryEscape(username)),
 	}, 204)
 	return err
 }

--- a/bitbucket/bitbucket_repository_permission_service.go
+++ b/bitbucket/bitbucket_repository_permission_service.go
@@ -5,6 +5,7 @@ import (
 	"github.com/yunarta/terraform-api-transport/transport"
 	"github.com/yunarta/terraform-atlassian-api-client/util"
 	"net/http"
+	"net/url"
 )
 
 const (
@@ -59,7 +60,7 @@ func (service *RepositoryService) readGroupsPermission(projectKey string, slug s
 func (service *RepositoryService) addGroupPermission(projectKey string, slug string, name string, permission string) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodPut,
-		Url:    fmt.Sprintf(addGroupRepositoryPermissionEndPoint, projectKey, slug, name, permission),
+		Url:    fmt.Sprintf(addGroupRepositoryPermissionEndPoint, projectKey, slug, url.QueryEscape(name), url.QueryEscape(permission)),
 	}, 204)
 	return err
 }
@@ -67,7 +68,7 @@ func (service *RepositoryService) addGroupPermission(projectKey string, slug str
 func (service *RepositoryService) removeGroupPermission(projectKey string, slug string, name string) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodDelete,
-		Url:    fmt.Sprintf(groupRepositoryPermissionEndPoint, projectKey, slug, name),
+		Url:    fmt.Sprintf(groupRepositoryPermissionEndPoint, projectKey, slug, url.QueryEscape(name)),
 	}, 204)
 	return err
 }
@@ -93,7 +94,7 @@ func (service *RepositoryService) readUsersPermission(projectKey string, slug st
 func (service *RepositoryService) addUserPermission(projectKey string, slug string, username string, permission string) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodPut,
-		Url:    fmt.Sprintf(addUserRepositoryPermissionEndPoint, projectKey, slug, username, permission),
+		Url:    fmt.Sprintf(addUserRepositoryPermissionEndPoint, projectKey, slug, url.QueryEscape(username), url.QueryEscape(permission)),
 	}, 204)
 	return err
 }
@@ -101,7 +102,7 @@ func (service *RepositoryService) addUserPermission(projectKey string, slug stri
 func (service *RepositoryService) removeUserPermission(projectKey string, slug string, username string) error {
 	_, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodDelete,
-		Url:    fmt.Sprintf(userRepositoryPermissionEndPoint, projectKey, slug, username),
+		Url:    fmt.Sprintf(userRepositoryPermissionEndPoint, projectKey, slug, url.QueryEscape(username)),
 	}, 204)
 	return err
 }

--- a/jira/cloud/jira_project_role_service.go
+++ b/jira/cloud/jira_project_role_service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/yunarta/terraform-api-transport/transport"
 	"github.com/yunarta/terraform-atlassian-api-client/jira"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 )
@@ -110,10 +111,10 @@ func (service *ProjectRoleService) RemoveProjectRole(projectIdOrKey string, role
 
 	var queries = make([]string, 0)
 	queries = append(queries, collections.Map(userAccountIds, func(k string) string {
-		return fmt.Sprintf("&user=%s", k)
+		return fmt.Sprintf("&user=%s", url.QueryEscape(k))
 	})...)
 	queries = append(queries, collections.Map(groupIds, func(k string) string {
-		return fmt.Sprintf("&groupId=%s", k)
+		return fmt.Sprintf("&groupId=%s", url.QueryEscape(k))
 	})...)
 
 	if len(queries) > 0 {

--- a/jira/cloud/jira_user_service.go
+++ b/jira/cloud/jira_user_service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/yunarta/terraform-api-transport/transport"
 	"github.com/yunarta/terraform-atlassian-api-client/jira"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -20,7 +21,7 @@ func NewActorService(transport transport.PayloadTransport) *ActorService {
 func (service *ActorService) ReadUser(emailAddress string) (*jira.User, error) {
 	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodGet,
-		Url:    fmt.Sprintf("/rest/api/latest/user/search?query=%s", emailAddress),
+		Url:    fmt.Sprintf("/rest/api/latest/user/search?query=%s", url.QueryEscape(emailAddress)),
 	}, 200)
 	if err != nil {
 		return nil, err
@@ -44,7 +45,7 @@ func (service *ActorService) ReadUser(emailAddress string) (*jira.User, error) {
 func (service *ActorService) ReadGroup(name string) (*jira.Group, error) {
 	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
 		Method: http.MethodGet,
-		Url:    fmt.Sprintf("/rest/api/latest/groups/picker?query=%s", name),
+		Url:    fmt.Sprintf("/rest/api/latest/groups/picker?query=%s", url.QueryEscape(name)),
 	}, 200)
 	if err != nil {
 		return nil, err
@@ -67,7 +68,7 @@ func (service *ActorService) ReadGroup(name string) (*jira.Group, error) {
 
 func (service *ActorService) BulkGetUsers(accountIds []string) ([]jira.User, error) {
 	accountIdQuery := strings.Join(collections.Map(accountIds, func(e string) string {
-		return fmt.Sprintf("accountId=%s", e)
+		return fmt.Sprintf("accountId=%s", url.QueryEscape(e))
 	}), "&")
 
 	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
@@ -89,7 +90,7 @@ func (service *ActorService) BulkGetUsers(accountIds []string) ([]jira.User, err
 
 func (service *ActorService) BulkGetGroupsById(groupId []string) ([]jira.Group, error) {
 	groupIdQuery := strings.Join(collections.Map(groupId, func(e string) string {
-		return fmt.Sprintf("groupId=%s", e)
+		return fmt.Sprintf("groupId=%s", url.QueryEscape(e))
 	}), "&")
 
 	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{
@@ -111,7 +112,7 @@ func (service *ActorService) BulkGetGroupsById(groupId []string) ([]jira.Group, 
 
 func (service *ActorService) BulkGetGroupsByName(groupName []string) ([]jira.Group, error) {
 	groupNameQuery := strings.Join(collections.Map(groupName, func(e string) string {
-		return fmt.Sprintf("groupName=%s", e)
+		return fmt.Sprintf("groupName=%s", url.QueryEscape(e))
 	}), "&")
 
 	reply, err := service.transport.SendWithExpectedStatus(&transport.PayloadRequest{


### PR DESCRIPTION
Updated all API request URLs to use `url.QueryEscape` for query parameters, ensuring proper encoding of special characters. This improves reliability and prevents potential issues with malformed requests.